### PR TITLE
Update to jellyfish-sync@5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -303,9 +303,9 @@
       }
     },
     "@balena/jellyfish-sync": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-5.1.0.tgz",
-      "integrity": "sha512-D+GdAzwyodIE0Orp9tjWY7pkk4v7T3uSzOAbBWOa5XnEgE24YAHmHVGmBxMBBdwWfZr93sO0JOv37l4KZQazGg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-sync/-/jellyfish-sync-5.2.0.tgz",
+      "integrity": "sha512-QDb3JMzTvjn9ju1eEsybCt9PIx9wVA9V0IIklUpLvKVcF6XM/bw0M7OqZjFkId/Iy+AR19mo3dAhda1zO0Desg==",
       "requires": {
         "@balena/jellyfish-assert": "^1.0.62",
         "@balena/jellyfish-logger": "1.0.42",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@balena/jellyfish-environment": "^2.4.23",
     "@balena/jellyfish-plugin-base": "^1.2.30",
     "@balena/jellyfish-queue": "0.0.459",
-    "@balena/jellyfish-sync": "^5.1.0",
+    "@balena/jellyfish-sync": "^5.2.0",
     "@balena/jellyfish-uuid": "^1.0.71",
     "@balena/jellyfish-worker": "^3.1.6",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
This change allows sync integrations to use JSONpatch when updating
contracts

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>