### PR TITLE
Remove TestSuite integration parameter

### DIFF
--- a/lib/integration/sync/scenario.ts
+++ b/lib/integration/sync/scenario.ts
@@ -509,7 +509,6 @@ function getTestCaseOptions(
 	suite: TestSuite,
 ): TestCaseOptions {
 	return {
-		constructor: suite.integration,
 		source: suite.source,
 		options: Object.assign(
 			{

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,7 +34,6 @@ export interface TestSuite {
 	basePath: string;
 	plugins: any[];
 	cards: string[];
-	integration: any;
 	scenarios: {
 		[key: string]: {
 			expected: any;


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Remove unnecessary `TestSuite` `integration` parameter.

Test PR: https://github.com/product-os/jellyfish-plugin-outreach/pull/6