### PR TITLE
Allow baseUrl to be a RegExp

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,7 +41,7 @@ export interface TestSuite {
 			headIndex?: number;
 		};
 	};
-	baseUrl: string;
+	baseUrl: string | RegExp;
 	stubRegex: object;
 	source: string;
 	isAuthorized: any;


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Allow `baseUrl` to be either a string or a RegExp