### PR TITLE
Improve stub not found warning message

### DIFF
--- a/lib/integration/sync/scenario.ts
+++ b/lib/integration/sync/scenario.ts
@@ -103,7 +103,11 @@ function getVariations(sequence: any, options: any): Variation[] {
  */
 function requireStub(basePath: string, offset: any, name: string): any {
 	if (offset === 0) {
-		console.warn(`Stub not found: ${name}`);
+		console.warn(
+			'Stub not found (possibly to simulate a 404):',
+			`\n\tName: ${name}`,
+			`\n\tBase Path: ${basePath}`,
+		);
 		return null;
 	}
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Improve `Stub not found` warning message to include the test case base path along with a note about how the lack of a stub may be on purpose to simulate a `404` from the external service. This bit me while looking into two "missing" stubs in `plugin-discourse`: https://github.com/product-os/jellyfish-plugin-discourse/pull/37. It was a waste of time as these stubs are explicitly left out to simulate a `404` response from Discourse.