### PR TITLE
Add translate test howto doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ syncIntegrationScenario.run(ava, {
 
 # Documentation
 
+[**Writing translate tests**](https://github.com/product-os/jellyfish-test-harness/blob/master/doc/writing-translate-tests.markdown)
+
 [![Publish Documentation](https://github.com/product-os/jellyfish-test-harness/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/product-os/jellyfish-test-harness/actions/workflows/publish-docs.yml)
 
 Visit the website for complete documentation: https://product-os.github.io/jellyfish-test-harness

--- a/doc/writing-translate-tests.markdown
+++ b/doc/writing-translate-tests.markdown
@@ -1,0 +1,42 @@
+# How to write tests
+
+Tests follow this file structure:
+
+```
+[test-name]/
+    stubs/
+        user-[username].json
+    expected.json
+    01.json
+    02.json
+    ...
+```
+
+Tests also have to be included in the appropriate `tests/integration/sync/webhooks/[source]/index.js` such as:
+
+```js
+'check-run': {
+  expected: require('./check-run/expected.json'),
+  steps: [
+    require('./check-run/01.json')
+  ]
+},
+```
+
+As well as in the `cards` in `tests/integration/sync/[source]-translate.spec.js` such as:
+
+```js
+syncIntegrationScenario.run(ava, {
+	basePath: __dirname,
+	plugins: [ ActionLibrary, DefaultPlugin ],
+	cards: [ 'issue', 'pull-request', 'message', 'repository', 'gh-push', 'check-run' ]
+  ...
+```
+
+### `expected.json`
+
+What are `head` and `tail`?
+
+`head` is main contract being synced. _don't know entirely what this means but it seems to be what you want it to start as_
+
+`tail` is the actions that are taken to make the contract, so `create` and `update` contracts that are the operations that create or update your contract.


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Moving the translate test howto doc from `plugin-default` to this repo