### PR TITLE
Add option to ignore fields on head assert

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -45,7 +45,14 @@ export interface TestSuite {
 	stubRegex: object;
 	source: string;
 	isAuthorized: any;
-	options?: any;
+	options?: {
+		token?: any;
+		head?: {
+			ignore: {
+				[key: string]: string[];
+			};
+		};
+	};
 	before?: (context: TestContext) => void;
 	beforeEach?: (context: TestContext) => void;
 	after?: (context: TestContext) => void;


### PR DESCRIPTION
This should be used carefully and sparingly. The main use case
is when dealing with unpredictable evaluated field values.

Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

The current, and only, use case for this option at the moment is to handle the unpredictable `support-thread` `data.lastMessage` values. This is an evaluated field, and the expected head object sometimes has this value and sometimes doesn't depending on the order of the operations being performed during the translate tests. This means that we cannot properly define the head for these cases with JSON alone. The `plugin-front` and `plugin-discourse` translate tests are currently failing because of this and these changes in `test-harness` will allow us to pick `data.lastMessage` from the real head object and merge it into the expected head object we assert with in the same way we currently pick and merge `id`, `created_at`, etc.

I also toyed with the idea of automatically "ignoring" (picking and merging) all fields that have a `$$formula` defined, but felt this to be a bit too broad and therefore dangerous. There is also the possibility of wanting a translate test case to assert the result of a predictable evaluated field.

An example of failing tests in a `plugin-front` PR caused by the unpredictable evaluated field value: https://ci.balena-dev.com/builds/1330622
```
sut_1       |     - Expected
sut_1       |     + Received
sut_1       | 
sut_1       |     @@ -5,10 +5,48 @@
sut_1       |         "data": Object {
sut_1       |           "alertsUser": Array [],
sut_1       |           "description": "",
sut_1       |           "environment": "production",
sut_1       |           "inbox": "S/Paid_Support",
sut_1       |     +     "lastMessage": Object {
sut_1       |     +       "active": true,
sut_1       |     +       "capabilities": Array [],
sut_1       |     +       "created_at": "2021-08-20T09:55:36.882Z",
sut_1       |     +       "data": Object {
sut_1       |     +         "actor": "d7befef5-713c-476a-b85d-1b4bdb5ac7f2",
sut_1       |     +         "mirrors": Array [
sut_1       |     +           "https://api2.frontapp.com/messages/msg_26k77bn",
sut_1       |     +         ],
sut_1       |     +         "origin": "external-event-da6d5c79-33e5-4b89-b158-9bbf4813d7d8@1.0.0",
sut_1       |     +         "payload": Object {
sut_1       |     +           "alertsGroup": Array [],
sut_1       |     +           "alertsUser": Array [],
sut_1       |     +           "mentionsGroup": Array [],
sut_1       |     +           "mentionsUser": Array [],
sut_1       |     +           "message": "<div><p>No worries. I've worked around it for now by pinning to an older base image.</p>
sut_1       |     + </div>",
sut_1       |     +         },
sut_1       |     +         "target": "17f95290-8e2f-4c51-b0df-87e25bcf0712",
sut_1       |     +         "timestamp": "2018-12-18T18:32:53.000Z",
sut_1       |     +         "translateDate": "2019-01-02T16:08:45.557Z",
sut_1       |     +       },
sut_1       |     +       "id": "42a73eb4-dd7d-40f0-b460-66212927a4c5",
sut_1       |     +       "linked_at": Object {
sut_1       |     +         "has attached element": "2021-08-20T09:55:36.904Z",
sut_1       |     +         "is attached to": "2021-08-20T09:55:36.927Z",
sut_1       |     +       },
sut_1       |     +       "links": Object {},
sut_1       |     +       "loop": null,
sut_1       |     +       "markers": Array [],
sut_1       |     +       "name": null,
sut_1       |     +       "requires": Array [],
sut_1       |     +       "slug": "message-1-0-0-front-msg-26k77bn",
sut_1       |     +       "tags": Array [],
sut_1       |     +       "type": "message@1.0.0",
sut_1       |     +       "updated_at": null,
sut_1       |     +       "version": "1.0.0",
sut_1       |     +     },
sut_1       |           "mentionsUser": Array [],
```