### PR TITLE
Update types through worker on bootstrap

### DIFF
--- a/lib/integration/helpers.ts
+++ b/lib/integration/helpers.ts
@@ -305,6 +305,19 @@ export const before = async (
 	);
 	testWorker.setTypeContracts(context, types);
 
+	// Update type cards through the worker for generated triggers, etc
+	for (const contract of types) {
+		await testWorker.replaceCard(
+			context,
+			adminSessionToken,
+			testWorker.typeContracts['type@1.0.0'],
+			{
+				attachEvents: false,
+			},
+			contract,
+		);
+	}
+
 	const triggers = await jellyfish.query<TypeContract>(
 		context,
 		adminSessionToken,


### PR DESCRIPTION
If we don't update types through the worker we end up with a system
without triggers generated by jellyscript.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>