### PR TITLE
Add action-test-originator to bootstrap

### DIFF
--- a/lib/integration/helpers.ts
+++ b/lib/integration/helpers.ts
@@ -200,7 +200,35 @@ export const before = async (
 	});
 
 	const allCards = pluginManager.getCards(pluginContext, cardMixins);
+	allCards['action-test-originator'] = Object.assign(
+		{},
+		allCards['action-create-card'],
+		{
+			slug: 'action-test-originator',
+		},
+	);
+
 	const actionLibrary = pluginManager.getActions(pluginContext);
+	Object.assign(actionLibrary, {
+		'action-test-originator': {
+			handler: async (
+				session: string,
+				handlerCtx: any,
+				card: any,
+				request: any,
+			) => {
+				request.arguments.properties.data =
+					request.arguments.properties.data || {};
+				request.arguments.properties.data.originator = request.originator;
+				return actionLibrary['action-create-card'].handler(
+					session,
+					handlerCtx,
+					card,
+					request,
+				);
+			},
+		},
+	});
 
 	const adminSessionToken = jellyfish.sessions!.admin;
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Trying adding `action-test-originator` card and action for worker integration tests:
- https://github.com/product-os/jellyfish-worker/blob/22cc1648a61939acfa36116fe6ba83a99ff1f6bd/test/integration/helpers.ts#L50
- https://github.com/product-os/jellyfish-worker/blob/22cc1648a61939acfa36116fe6ba83a99ff1f6bd/test/integration/helpers.ts#L62