### PR TITLE
Update dependencies, imports, and API

### DIFF
--- a/lib/integration/helpers.ts
+++ b/lib/integration/helpers.ts
@@ -136,11 +136,10 @@ export interface IntegrationTestContext {
 }
 
 export const before = async (
-	plugins: any[],
-	options: SetupOptions = {},
+	options: SetupOptions,
 ): Promise<IntegrationTestContext> => {
 	const pluginManager = new PluginManager(pluginLogContext, {
-		plugins,
+		plugins: options.plugins,
 	});
 
 	const suffix = options.suffix || generateRandomID();

--- a/lib/integration/sync/scenario.ts
+++ b/lib/integration/sync/scenario.ts
@@ -1,28 +1,29 @@
-import type { Contract } from '@balena/jellyfish-types/build/core';
 import { strict as assert } from 'assert';
-import clone from 'lodash/clone';
-import cloneDeep from 'lodash/cloneDeep';
-import compact from 'lodash/compact';
-import difference from 'lodash/difference';
-import each from 'lodash/each';
-import filter from 'lodash/filter';
-import findIndex from 'lodash/findIndex';
-import first from 'lodash/first';
-import get from 'lodash/get';
-import includes from 'lodash/includes';
-import isEqual from 'lodash/isEqual';
-import kebabCase from 'lodash/kebabCase';
-import keys from 'lodash/keys';
-import last from 'lodash/last';
-import map from 'lodash/map';
-import merge from 'lodash/merge';
-import partial from 'lodash/partial';
-import pick from 'lodash/pick';
-import sortBy from 'lodash/sortBy';
+import type { Contract } from '@balena/jellyfish-types/build/core';
+import {
+	clone,
+	cloneDeep,
+	compact,
+	difference,
+	each,
+	filter,
+	findIndex,
+	first,
+	get,
+	includes,
+	isEqual,
+	kebabCase,
+	keys,
+	last,
+	map,
+	merge,
+	partial,
+	pick,
+	sortBy,
+} from 'lodash';
 import nock from 'nock';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
-
 import type {
 	TestContext,
 	TestCaseOptions,
@@ -171,8 +172,8 @@ export async function webhookScenario(
 			payload: step.payload,
 		};
 
-		const event = await context.jellyfish.insertCard(
-			context.context,
+		const event = await context.kernel.insertCard(
+			context.logContext,
 			context.session,
 			{
 				type: 'external-event@1.0.0',
@@ -188,7 +189,7 @@ export async function webhookScenario(
 			context.worker.getId(),
 			context.session,
 			{
-				context: context.context,
+				logContext: context.logContext,
 				action: 'action-integration-import-event@1.0.0',
 				card: event.id,
 				type: event.type,
@@ -198,7 +199,7 @@ export async function webhookScenario(
 
 		await context.flush(context.session);
 		const result = await context.queue.producer.waitResults(
-			context.context,
+			context.logContext,
 			request,
 		);
 		assert.ok(result.error === false);
@@ -212,13 +213,10 @@ export async function webhookScenario(
 
 	assert.ok(cards.length > 0);
 
-	const head = await context.jellyfish.getCardById(
-		context.context,
+	const head = await context.kernel.getCardById(
+		context.logContext,
 		context.session,
 		cards[testCase.headIndex].id,
-		{
-			type: cards[testCase.headIndex].type,
-		},
 	);
 
 	// TODO: Remove once we fully support versioned
@@ -232,8 +230,8 @@ export async function webhookScenario(
 	Reflect.deleteProperty(head.data, 'origin');
 	Reflect.deleteProperty(head.data, 'translateDate');
 
-	const timeline = await context.jellyfish.query(
-		context.context,
+	const timeline = await context.kernel.query(
+		context.logContext,
 		context.session,
 		{
 			type: 'object',
@@ -309,8 +307,8 @@ export async function webhookScenario(
 				card.type = `${card.type}@1.0.0`;
 			}
 
-			const actorCard = await context.jellyfish.getCardById(
-				context.context,
+			const actorCard = await context.kernel.getCardById(
+				context.logContext,
 				context.session,
 				card.data.actor,
 			);
@@ -431,21 +429,21 @@ export async function before(
 	context: TestContext,
 	plugins: any[] = [],
 	cards: any[] = [],
-): Promise<void> {
+): Promise<TestContext> {
 	loadPlugins(context, plugins);
 
-	await worker.before(context, {
+	const context = await worker.before({
 		suffix: TRANSLATE_PREFIX,
 	});
 
-	context.syncContext = context.context.sync.getActionContext(
+	const syncContext = context.logContext.sync.getActionContext(
 		'test',
-		context.worker.getActionContext(context.context),
-		context.context,
+		context.worker.getActionContext(context.logContext),
+		context.logContext,
 		context.session,
 	);
 
-	await insertCards(context, context.plugins.cards, [
+	await insertCards(context, context.session, context.plugins.cards, [
 		'external-event',
 		'action-integration-import-event',
 		...cards,
@@ -483,10 +481,9 @@ export async function afterEach(context: TestContext): Promise<void> {
  * @param context - test context
  */
 export async function restore(context: TestContext): Promise<void> {
+	await context.kernel.reset(context.logContext);
 	// TODO: Should avoid this level of manual manipulation of the backend
-	await context.jellyfish.backend.connection.any('DELETE FROM links2');
-	await context.jellyfish.backend.connection.any('DELETE FROM cards');
-	await context.jellyfish.backend.connection.any(
+	await context.kernel.backend.connection.any(
 		'INSERT INTO cards SELECT * FROM cards_copy',
 	);
 }
@@ -498,7 +495,7 @@ export async function restore(context: TestContext): Promise<void> {
  * @param context - test context
  */
 export async function save(context: TestContext): Promise<void> {
-	await context.jellyfish.backend.connection.any(
+	await context.kernel.backend.connection.any(
 		'CREATE TABLE cards_copy AS TABLE cards',
 	);
 }
@@ -519,7 +516,7 @@ function getTestCaseOptions(
 		source: suite.source,
 		options: Object.assign(
 			{
-				context: context.context,
+				context: context.logContext,
 				session: context.session,
 				actor: context.actor.id,
 			},
@@ -536,32 +533,33 @@ function getTestCaseOptions(
  * @param suite - test suite
  */
 export async function run(tester: Tester, suite: TestSuite): Promise<void> {
-	const context: TestContext = {};
+	let context: TestContext | null = null;
 
 	tester.before(async () => {
-		await before(context, suite.plugins, suite.cards);
+		context = await before(context, suite.plugins, suite.cards);
 		if (suite.before) {
-			await suite.before(context);
+			suite.before(context);
 		}
 		await save(context);
 	});
 
 	tester.beforeEach(async () => {
 		if (suite.beforeEach) {
-			await suite.beforeEach(context);
+			suite.beforeEach(context);
 		}
 	});
 
 	tester.after(async () => {
 		if (suite.after) {
-			await suite.after(context);
+			suite.after(context);
 		}
 		await after(context);
+		context = null;
 	});
 
 	tester.afterEach(async () => {
 		if (suite.afterEach) {
-			await suite.afterEach(context);
+			suite.afterEach(context);
 		}
 		await afterEach(context);
 	});
@@ -597,7 +595,7 @@ export async function run(tester: Tester, suite: TestSuite): Promise<void> {
 
 			tester.test(`(${variation.name}) ${testCaseName}`, async () => {
 				if (suite.pre) {
-					await suite.pre(context);
+					suite.pre(context);
 				}
 
 				await webhookScenario(

--- a/lib/integration/sync/webhook-capturer.ts
+++ b/lib/integration/sync/webhook-capturer.ts
@@ -1,9 +1,9 @@
-import padStart from 'lodash/padStart';
+import bodyParser from 'body-parser';
 import express from 'express';
 import fs from 'fs';
-import path from 'path';
+import { padStart } from 'lodash';
 import morgan from 'morgan';
-import bodyParser from 'body-parser';
+import path from 'path';
 
 export function setup() {
 	const outputDirectory = process.cwd();

--- a/lib/integration/utils.spec.ts
+++ b/lib/integration/utils.spec.ts
@@ -11,7 +11,7 @@ describe('loadPlugins()', () => {
 				},
 			},
 		};
-		loadPlugins(test, []);
+		loadPlugins([]);
 		expect(test.context.plugins.cards).toEqual({});
 		expect(test.context.plugins.actions).toEqual({});
 		expect(test.context.plugins.syncIntegrations).toEqual({});

--- a/lib/integration/utils.ts
+++ b/lib/integration/utils.ts
@@ -6,30 +6,27 @@ import type { JellyfishPluginConstructor } from '@balena/jellyfish-plugin-base';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import combinatorics from 'js-combinatorics/commonjs/combinatorics';
 import { v4 as uuidv4 } from 'uuid';
-import type { BackendTestContext, TestContext } from '../types';
+import type { BackendTestContext } from '../types';
 
 /**
  * @summary Load Jellyfish plugins.
  * @function
  *
- * @param context - test context
- * @param plugins - Jellyfish plugin constructors
+ * @param pluginConstructors - Jellyfish plugin constructors
  */
 export function loadPlugins(
-	context: TestContext,
-	plugins: JellyfishPluginConstructor[],
-): void {
-	if (context.plugins) {
-		return;
-	}
-
-	const pluginManager = new PluginManager(context.context, {
-		plugins: plugins || [],
+	pluginConstructors: JellyfishPluginConstructor[],
+): any {
+	const context = {
+		id: `test-harness-${uuidv4()}`,
+	};
+	const pluginManager = new PluginManager(context, {
+		plugins: pluginConstructors || [],
 	});
-	context.plugins = {
-		cards: pluginManager.getCards(context.context, coreMixins),
-		actions: pluginManager.getActions(context.context),
-		syncIntegrations: pluginManager.getSyncIntegrations(context.context),
+	return {
+		cards: pluginManager.getCards(context, coreMixins),
+		actions: pluginManager.getActions(context),
+		syncIntegrations: pluginManager.getSyncIntegrations(context),
 	};
 }
 

--- a/lib/integration/utils.ts
+++ b/lib/integration/utils.ts
@@ -3,10 +3,10 @@
 import { cardMixins as coreMixins } from '@balena/jellyfish-core';
 import { PluginManager } from '@balena/jellyfish-plugin-base';
 import type { JellyfishPluginConstructor } from '@balena/jellyfish-plugin-base';
+import type { Contract } from '@balena/jellyfish-types/build/core';
+import combinatorics from 'js-combinatorics/commonjs/combinatorics';
 import { v4 as uuidv4 } from 'uuid';
-import type { TestContext } from '../types';
-
-const combinatorics = require('js-combinatorics/commonjs/combinatorics');
+import type { BackendTestContext, TestContext } from '../types';
 
 /**
  * @summary Load Jellyfish plugins.
@@ -42,15 +42,16 @@ export function loadPlugins(
  * @param cardSlugs - plugin card slugs
  */
 export async function insertCards(
-	context: TestContext,
-	allCards: any,
+	context: BackendTestContext,
+	session: string,
+	allCards: Contract[],
 	cardSlugs: string[],
 ): Promise<void> {
 	await Promise.all(
 		cardSlugs.map((cardSlug: string) => {
-			return context.jellyfish.insertCard(
-				context.context,
-				context.session,
+			return context.kernel.insertCard(
+				context.logContext,
+				session,
 				allCards[cardSlug],
 			);
 		}),
@@ -71,6 +72,10 @@ export function generateRandomID(): string {
 	return uuidv4();
 }
 
+export interface RandomSlugOptions {
+	prefix: string;
+}
+
 /**
  * @summary Generate and return random slug
  * @function
@@ -82,7 +87,7 @@ export function generateRandomID(): string {
  *   const slug = generateRandomSlug();
  * ```
  */
-export function generateRandomSlug(options: any): string {
+export function generateRandomSlug(options: RandomSlugOptions): string {
 	const slug = generateRandomID();
 	if (options && options.prefix) {
 		return `${options.prefix}-${slug}`;

--- a/lib/integration/worker/helpers.ts
+++ b/lib/integration/worker/helpers.ts
@@ -1,39 +1,39 @@
-// tslint:disable: no-var-requires
+import { coreErrors } from '@balena/jellyfish-core';
+import {
+	Consumer,
+	errors as queueErrors,
+	Producer,
+} from '@balena/jellyfish-queue';
+import { Sync } from '@balena/jellyfish-sync';
+import type {
+	SessionContract,
+	UserContract,
+} from '@balena/jellyfish-types/build/core';
+import { CARDS as workerCards, Worker } from '@balena/jellyfish-worker';
+import errio from 'errio';
 import { v4 as uuidv4 } from 'uuid';
+import * as backendHelpers from '../backend-helpers';
 import type { ActionRequest, SetupOptions, TestContext } from '../../types';
-import * as helpers from '../backend-helpers';
-import { generateRandomID, generateRandomSlug, insertCards } from '../utils';
+import { insertCards } from '../utils';
 
-const Consumer = require('@balena/jellyfish-queue').Consumer;
-const Producer = require('@balena/jellyfish-queue').Producer;
-const Worker = require('@balena/jellyfish-worker').Worker;
-const Sync = require('@balena/jellyfish-sync').Sync;
-const queueErrors = require('@balena/jellyfish-queue').errors;
-const errio = require('errio');
+async function runBefore(options?: SetupOptions): Promise<TestContext> {
+	const backendContext = await backendHelpers.before(options);
+	const session = backendContext.kernel.sessions!.admin;
 
-async function runBefore(
-	context: TestContext,
-	options: SetupOptions,
-): Promise<void> {
-	const integrations = context.plugins.syncIntegrations;
-
-	await helpers.before(context, options);
-	context.jellyfish = context.kernel;
-	context.session = context.jellyfish.sessions.admin;
-
-	const session = await context.jellyfish.getCardById(
-		context.context,
-		context.session,
-		context.session,
+	const sessionCard = await backendContext.kernel.getCardById<SessionContract>(
+		backendContext.logContext,
+		session,
+		session,
 	);
 
-	context.actor = await context.jellyfish.getCardById(
-		context.context,
-		context.session,
-		session.data.actor,
+	const sessionActor = await backendContext.kernel.getCardById<UserContract>(
+		backendContext.logContext,
+		session,
+		sessionCard!.data.actor,
 	);
 
-	context.context.sync = new Sync({
+	const integrations = options.plugins.syncIntegrations;
+	backendContext.logContext.sync = new Sync({
 		integrations,
 	});
 
@@ -47,45 +47,59 @@ async function runBefore(
 		'action-update-card',
 		'action-delete-card',
 	];
+	await insertCards(
+		backendContext,
+		session,
+		options.plugins.cards,
+		cardsToInsert,
+	);
 
-	await insertCards(context, context.plugins.cards, cardsToInsert);
-
-	context.queue = {};
-	context.queue.errors = queueErrors;
-
-	context.queue.consumer = new Consumer(context.jellyfish, context.session);
-
+	const queueActor = uuidv4();
 	const consumedActionRequests: ActionRequest[] = [];
 
-	await context.queue.consumer.initializeWithEventHandler(
-		context.context,
+	const queueConsumer = new Consumer(backendContext.kernel, session);
+	await queueConsumer.initializeWithEventHandler(
+		backendContext.logContext,
 		(actionRequest: ActionRequest) => {
 			consumedActionRequests.push(actionRequest);
+
+			return new Promise(null);
 		},
 	);
 
-	context.queueActor = uuidv4();
+	const queueProducer = new Producer(backendContext.kernel, session);
+	await queueProducer.initialize(backendContext.logContext);
 
-	context.dequeue = async (times = 50) => {
-		if (consumedActionRequests.length === 0) {
-			if (times <= 0) {
-				return null;
+	const dequeue = async (times = 50) => {
+		for (let i = 0; i < times; i++) {
+			if (consumedActionRequests.length > 0) {
+				return consumedActionRequests.shift();
 			}
-
-			await new Promise((resolve) => {
-				setTimeout(resolve, 10);
-			});
-			return context.dequeue(times - 1);
 		}
 
-		return consumedActionRequests.shift();
+		return null;
 	};
 
-	context.queue.producer = new Producer(context.jellyfish, context.session);
-
-	await context.queue.producer.initialize(context.context);
-	context.generateRandomSlug = generateRandomSlug;
-	context.generateRandomID = generateRandomID;
+	return {
+		session,
+		sessionActor,
+		flush: async (_session: string) => {
+			/* empty */
+		},
+		flushAll: async (_ssn: string) => {
+			/* empty */
+		},
+		processAction: async (_session: string, _action: ActionRequest) => {
+			/* empty */
+		},
+		queue: {
+			actor: queueActor,
+			consumer: queueConsumer,
+			producer: queueProducer,
+		},
+		dequeue,
+		...backendContext,
+	};
 }
 
 /**
@@ -95,48 +109,45 @@ async function runBefore(
  * @param context - test context
  */
 async function after(context: TestContext): Promise<void> {
-	if (context.queue) {
-		await context.queue.consumer.cancel();
-	}
-
-	if (context.jellyfish) {
-		await helpers.after(context);
-	}
+	await context.queue.consumer.cancel();
+	await backendHelpers.after(context);
 }
 
 export const jellyfish = {
-	before: async (context: TestContext) => {
-		await runBefore(context, {
-			suffix: '',
-		});
+	before: async () => {
+		const context = await runBefore();
+		await insertCards(
+			context,
+			context.session,
+			// TODO: remove these anys by fixing the worker
+			workerCards as any,
+			[
+				workerCards.update,
+				workerCards.create as any,
+				workerCards['triggered-action'],
+			],
+		);
 
-		const workerCards = require('@balena/jellyfish-worker').CARDS;
-		await insertCards(context, workerCards, [
-			workerCards.update,
-			workerCards.create,
-			workerCards['triggered-action'],
-		]);
+		return context;
 	},
 
-	after: async (context: TestContext) => {
-		await after(context);
-	},
+	after,
 };
 
 export const worker = {
-	before: async (context: TestContext, options: SetupOptions) => {
-		await runBefore(context, {
+	before: async (options: SetupOptions) => {
+		const context = await runBefore({
 			suffix: options.suffix,
 		});
 
 		context.worker = new Worker(
-			context.jellyfish,
+			context.kernel,
 			context.session,
-			context.plugins.actions,
+			options.plugins.actions,
 			context.queue.consumer,
 			context.queue.producer,
 		);
-		await context.worker.initialize(context.context);
+		await context.worker.initialize(context.logContext);
 
 		context.flush = async (session: string) => {
 			const request = await context.dequeue();
@@ -150,8 +161,8 @@ export const worker = {
 			if (result.error) {
 				const Constructor =
 					context.worker.errors[result.data.name] ||
-					context.queue.errors[result.data.name] ||
-					context.jellyfish.errors[result.data.name] ||
+					queueErrors[result.data.name] ||
+					coreErrors[result.data.name] ||
 					Error;
 
 				const error = new Constructor(result.data.message);
@@ -167,7 +178,6 @@ export const worker = {
 				}
 			} catch {
 				// Once an error is thrown, there are no more requests to dequeue
-				return;
 			}
 		};
 
@@ -175,10 +185,15 @@ export const worker = {
 			const createRequest = await context.queue.producer.enqueue(
 				context.worker.getId(),
 				session,
-				action,
+				// TODO: typing
+				action as any,
 			);
 			await context.flushAll(session);
-			return context.queue.producer.waitResults(context, createRequest);
+
+			return context.queue.producer.waitResults(
+				context.logContext,
+				createRequest,
+			);
 		};
 	},
 	after,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,9 +1,50 @@
+import type { CoreKernel, MemoryCache } from '@balena/jellyfish-core';
+import type { LogContext } from '@balena/jellyfish-logger';
 import type { ActionFile } from '@balena/jellyfish-plugin-base';
-import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+import type { IntegrationConstructor } from '@balena/jellyfish-sync';
+import type {
+	Consumer,
+	Producer,
+	ProducerResults,
+} from '@balena/jellyfish-queue';
+import type {
+	Contract,
+	ContractDefinition,
+	UserContract,
+} from '@balena/jellyfish-types/build/core';
 import type { Action } from '@balena/jellyfish-types/build/worker';
+import type { RandomSlugOptions } from './integration/utils';
+
+export interface BackendTestContext {
+	kernel: CoreKernel;
+	logContext: LogContext;
+	cache: MemoryCache;
+	generateRandomSlug: (options: RandomSlugOptions) => string;
+	generateRandomID: () => string;
+}
 
 export interface TestContext {
-	[key: string]: any;
+	session: string;
+	sessionActor: UserContract;
+	// TODO: proper type
+	worker?: any;
+	flush: (session: string) => Promise<void>;
+	flushAll: (ssn: string) => Promise<void>;
+	processAction: (
+		session: string,
+		action: ActionRequest,
+	) => Promise<ProducerResults>;
+	queue: {
+		actor: string;
+		consumer: Consumer;
+		producer: Producer;
+	};
+	dequeue: (times?: number) => Promise<ActionRequest | null>;
+	kernel: CoreKernel;
+	logContext: LogContext;
+	cache: MemoryCache;
+	generateRandomSlug: (options: RandomSlugOptions) => string;
+	generateRandomID: () => string;
 }
 
 export interface ActionRequest {
@@ -12,6 +53,13 @@ export interface ActionRequest {
 
 // TS-TODO: Use proper type for worker
 export interface SetupOptions {
+	plugins?: {
+		actions?: ActionLibrary;
+		cards?: Contract[];
+		syncIntegrations?: {
+			[key: string]: IntegrationConstructor;
+		};
+	};
 	suffix?: string;
 	skipConnect?: boolean;
 	cards?: ContractDefinition[];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,14 +1,15 @@
 import type { CoreKernel, MemoryCache } from '@balena/jellyfish-core';
 import type { LogContext } from '@balena/jellyfish-logger';
-import type { ActionFile } from '@balena/jellyfish-plugin-base';
-import type { IntegrationConstructor } from '@balena/jellyfish-sync';
+import type {
+	ActionFile,
+	JellyfishPluginConstructor,
+} from '@balena/jellyfish-plugin-base';
 import type {
 	Consumer,
 	Producer,
 	ProducerResults,
 } from '@balena/jellyfish-queue';
 import type {
-	Contract,
 	ContractDefinition,
 	UserContract,
 } from '@balena/jellyfish-types/build/core';
@@ -53,13 +54,7 @@ export interface ActionRequest {
 
 // TS-TODO: Use proper type for worker
 export interface SetupOptions {
-	plugins?: {
-		actions?: ActionLibrary;
-		cards?: Contract[];
-		syncIntegrations?: {
-			[key: string]: IntegrationConstructor;
-		};
-	};
+	plugins: JellyfishPluginConstructor[];
 	suffix?: string;
 	skipConnect?: boolean;
 	cards?: ContractDefinition[];
@@ -80,6 +75,15 @@ export interface Tester {
 	test: (title: string, fn: () => Promise<void>) => void;
 }
 
+export interface TestSuiteOptions {
+	token?: any;
+	head?: {
+		ignore: {
+			[key: string]: string[];
+		};
+	};
+}
+
 export interface TestSuite {
 	basePath: string;
 	plugins: any[];
@@ -95,14 +99,7 @@ export interface TestSuite {
 	stubRegex: object;
 	source: string;
 	isAuthorized: any;
-	options?: {
-		token?: any;
-		head?: {
-			ignore: {
-				[key: string]: string[];
-			};
-		};
-	};
+	options?: TestSuiteOptions;
 	before?: (context: TestContext) => void;
 	beforeEach?: (context: TestContext) => void;
 	after?: (context: TestContext) => void;
@@ -114,9 +111,7 @@ export interface TestSuite {
 export interface TestCaseOptions {
 	constructor: any;
 	source: string;
-	options: {
-		context: TestContext;
-	};
+	options: TestSuiteOptions;
 }
 
 export interface ActionLibrary {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@balena/jellyfish-core": "^8.2.7",
+    "@balena/jellyfish-core": "^10.2.0",
     "@balena/jellyfish-environment": "^6.0.4",
+    "@balena/jellyfish-logger": "^4.0.5",
     "@balena/jellyfish-plugin-base": "^2.2.7",
-    "@balena/jellyfish-queue": "^1.0.395",
+    "@balena/jellyfish-queue": "^2.1.0",
     "@balena/jellyfish-sync": "^6.2.0",
     "@balena/jellyfish-worker": "^10.1.21",
     "body-parser": "^1.19.1",


### PR DESCRIPTION
Adapt to major updates to `jellyfish-core` and `jellyfish-queue`, plus minor updates to other packages. Imports were reorganized to avoid deep imports and use the original types instead of `jellyfish-types` or `any`, through many instances still remain. Additionally:

- Removed the `backend` field from the `TestContext` type. The `Kernel`s backend is an implementation detail and should not be accessed directly, much less constructed by external modules.
- Rename the `context.jellyfish` to `context.kernel`, as the latter is much more descriptive.
- `before*` functions don't accept a `context` as a first argument anymore. They instead return a `TestContext` object. Accepting a `TestContext` was causing multiple issues with typing and it is not necessary to pass a full context, just some optional data related to plugins.
- Removed code that isn't necessary with TypeScript.

Change-type: major
Signed-off-by: Carol Schulze <carol@balena.io>