### PR TITLE
Fix js-combinatorics import

### DIFF
--- a/lib/integration/utils.ts
+++ b/lib/integration/utils.ts
@@ -1,10 +1,8 @@
-// tslint:disable: no-var-requires
-
 import { cardMixins as coreMixins } from '@balena/jellyfish-core';
 import { PluginManager } from '@balena/jellyfish-plugin-base';
 import type { JellyfishPluginConstructor } from '@balena/jellyfish-plugin-base';
 import type { Contract } from '@balena/jellyfish-types/build/core';
-import combinatorics from 'js-combinatorics/commonjs/combinatorics';
+import * as Combinatorics from 'js-combinatorics/commonjs/combinatorics';
 import { v4 as uuidv4 } from 'uuid';
 import type { BackendTestContext } from '../types';
 
@@ -103,7 +101,7 @@ export class PermutationCombination {
 	[Symbol.iterator]() {
 		return (function* (it) {
 			for (let index = 1, l = it.length; index <= l; index++) {
-				yield* new combinatorics.Permutation(it, index);
+				yield* new Combinatorics.Permutation(it, index);
 			}
 		})(this.seed);
 	}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

[Recent changes](https://github.com/product-os/jellyfish-test-harness/commit/4350c57c86e9a8f95551b27dc8179cd120f9abde#diff-5da2f51fec02e37a99dee759fd479ec38a1d321c452198ea24bbfca89b296ad8R7) seem to have broken the test harness. Currently, attempting to use v9 of `test-harness` in any of the other repos results in:
```
(node:6391) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'Permutation' of undefined
(node:6391) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:6391) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 FAIL  test/integration/sync/typeform-translate.spec.ts
  ● Test suite failed to run

    Your test suite must contain at least one test.

      at onResult (node_modules/@jest/core/build/TestScheduler.js:175:18)
      at node_modules/@jest/core/build/TestScheduler.js:316:17
      at node_modules/emittery/index.js:260:13
          at Array.map (<anonymous>)
      at Emittery.emit (node_modules/emittery/index.js:258:23)
```